### PR TITLE
OmniSwitch: support locale change

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -56,5 +56,11 @@
                 <data android:scheme="package" />
             </intent-filter>
         </receiver>
+        <!-- to update labels -->
+        <receiver android:name="org.omnirom.omniswitch.LocaleChangeReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCALE_CHANGED"/>
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/src/org/omnirom/omniswitch/LocaleChangeReceiver.java
+++ b/src/org/omnirom/omniswitch/LocaleChangeReceiver.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2013 The OmniROM Project
+ *  Copyright (C) 2015 The OmniROM Project
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -22,15 +22,24 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.util.Log;
+import android.preference.PreferenceManager;
+import android.content.SharedPreferences;
 
-public class PackageReceiver extends BroadcastReceiver {
+import org.omnirom.omniswitch.SwitchConfiguration;
+
+public class LocaleChangeReceiver extends BroadcastReceiver {
     private static final boolean DEBUG = false;
 
     @Override
     public void onReceive(final Context context, Intent intent) {
-        if (DEBUG) Log.d("PackageReceiver", "onReceive " + intent.getAction());
+        if (DEBUG) Log.d("LocaleChangeReceiver", "onReceive " + intent.getAction());
         if (SwitchService.isRunning()){
             PackageManager.getInstance(context).updatePackageList();
+
+            // to force a reload of all adapters that show packages
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            boolean value = prefs.getBoolean("LOCALE_CHANGED", false);
+            prefs.edit().putBoolean("LOCALE_CHANGED", !value).commit();
         }
     }
 }

--- a/src/org/omnirom/omniswitch/PackageManager.java
+++ b/src/org/omnirom/omniswitch/PackageManager.java
@@ -39,8 +39,11 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.pm.ResolveInfo;
 import android.graphics.drawable.Drawable;
 import android.preference.PreferenceManager;
+import android.util.Log;
 
 public class PackageManager {
+    private static final boolean DEBUG = false;
+    private static final String TAG = "PackageManager";
 
     private Map<String, PackageItem> mInstalledPackages;
     private List<PackageItem> mInstalledPackagesList;
@@ -94,14 +97,14 @@ public class PackageManager {
 
     public synchronized List<PackageItem> getPackageList() {
         if(!mInitDone){
-            updatePackageList(false, null);
+            updatePackageList();
         }
         return mInstalledPackagesList;
     }
 
     public synchronized Map<String, PackageItem> getPackageMap() {
         if(!mInitDone){
-            updatePackageList(false, null);
+            updatePackageList();
         }
         return mInstalledPackages;
     }
@@ -134,7 +137,8 @@ public class PackageManager {
         return icon;
     }
 
-    public synchronized void updatePackageList(boolean removed, String pkg) {
+    public synchronized void updatePackageList() {
+        if (DEBUG) Log.d(TAG, "updatePackageList");
         final android.content.pm.PackageManager pm = mContext.getPackageManager();
         BitmapCache.getInstance(mContext).clear();
 

--- a/src/org/omnirom/omniswitch/SwitchService.java
+++ b/src/org/omnirom/omniswitch/SwitchService.java
@@ -77,7 +77,7 @@ public class SwitchService extends Service {
         filter.addAction(Intent.ACTION_SHUTDOWN);
 
         registerReceiver(mReceiver, filter);
-        PackageManager.getInstance(this).updatePackageList(false, null);
+        PackageManager.getInstance(this).updatePackageList();
 
         mPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         updatePrefs(mPrefs, null);


### PR DESCRIPTION
Update app labels correctly when locale is changed

Change-Id: I081ef18339e585af7c7ff449e49f0549a0fd6ad0
